### PR TITLE
Fix docstrings for config and scorecard

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,13 +3,13 @@ import json
 
 def get_config_value(config_key: str) -> str:
     """
-    Get the setting from the settings.json file.
+    Get the setting from the config.json file.
     Args:
         config_key: The settings string looks like: "DEVICE/LOCATION_ID"
                     with the equivalent json key being [DEVICE"]["LOCATION_ID"]
 
     Returns: The value of the json key
-    Examples: get_setting("DEVICE/LOCATION_ID")
+    Examples: get_config_value("DEVICE/LOCATION_ID")
 
     See Also: config.json
     References: config_example.json

--- a/versions/v1/user_routes.py
+++ b/versions/v1/user_routes.py
@@ -231,7 +231,7 @@ async def get_scorecard(scorecard_id: str,
     * HTTP exceptions are raised.
 
     If the response is successful, the scorecard HTML is parsed and converted into a structured format using the
-    `parse_scorecard` method. The parsed scorecard is then checked for validity
+    `parse_scores` method. The parsed scorecard is then checked for validity
     *. If it is valid, the grade point average is calculated using the `get_grade_point_average` method.
 
     Finally, the retrieved scorecard, grade point average, and a success message are returned as a `Scorecard` object.


### PR DESCRIPTION
## Summary
- clarify that configuration is read from `config.json`
- fix usage example to use `get_config_value`
- document the use of `parse_scores` in `get_scorecard`

## Testing
- `python -m py_compile config.py versions/v1/user_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6850548a6f4083289579009cd2c82a63