### PR TITLE
Add pytest-based unit and integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Run Tests
 
 on:
   push:
-    branches: ["master"]
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Run Tests
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest responses httpx
+
+      - name: Run tests
+        run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ fastapi==0.103.2
 pydantic==2.4.2
 uvicorn==0.23.2
 fastapi_versioning==0.10.0
+httpx==0.25.2
+responses==0.23.1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+import importlib
+import pytest
+
+
+def test_get_config_value_success(tmp_path, monkeypatch):
+    cfg = {"QIS": {"BASE_URL": "http://x", "SERVICE_PATH": "/s"}}
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps(cfg))
+    monkeypatch.chdir(tmp_path)
+    config = importlib.import_module('config')
+    importlib.reload(config)
+    assert config.get_config_value('QIS/BASE_URL') == 'http://x'
+
+
+def test_get_config_value_missing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = importlib.import_module('config')
+    importlib.reload(config)
+    with pytest.raises(FileNotFoundError):
+        config.get_config_value('QIS/BASE_URL')
+
+
+def test_get_config_value_key_error(tmp_path, monkeypatch):
+    cfg = {"QIS": {}}
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps(cfg))
+    monkeypatch.chdir(tmp_path)
+    config = importlib.import_module('config')
+    importlib.reload(config)
+    with pytest.raises(KeyError):
+        config.get_config_value('QIS/BASE_URL')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,60 @@
+import json
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+import responses
+
+
+@pytest.fixture(autouse=True)
+def config_and_client(tmp_path):
+    cfg = {"QIS": {"BASE_URL": "http://testserver", "SERVICE_PATH": "/service"}}
+    config_file = Path('config.json')
+    config_file.write_text(json.dumps(cfg))
+
+    import config as cfg_module
+    import versions.v1.utils as utils
+    import versions.v1.user_routes as routes
+    import main
+
+    importlib.reload(cfg_module)
+    importlib.reload(utils)
+    importlib.reload(routes)
+    importlib.reload(main)
+
+    client = TestClient(main.app)
+    yield client
+    config_file.unlink()
+
+
+@responses.activate
+def test_signin_success(config_and_client):
+    client = config_and_client
+    from versions.v1.user_routes import SIGNIN_URL, STUDY_POS_URL
+    login_html = '<div class="divloginstatus">' + ''.join('<span></span>' for _ in range(8)) + 'User</div>'
+    responses.add(responses.POST, SIGNIN_URL, body=login_html, status=200,
+                  headers={'Set-Cookie': 'JSESSIONID=ABC; Path=/; HttpOnly'})
+    study_html = (
+        '<div class="divloginstatus">' + ''.join('<span></span>' for _ in range(8)) + 'User</div>'
+        '<a href="page?asi=ASI123">Notenspiegel / Studienverlauf</a>'
+    )
+    responses.add(responses.GET, STUDY_POS_URL, body=study_html, status=200)
+
+    resp = client.post('/v1.0/signin', json={'username': 'u', 'password': 'p'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['session_cookie'] == 'ABC'
+    assert data['asi'] == 'ASI123'
+    assert data['user_display_name'] == 'User'
+
+
+@responses.activate
+def test_check_session_validity(config_and_client):
+    client = config_and_client
+    from versions.v1.user_routes import SERVICE_BASE_URL
+    check_url = f"{SERVICE_BASE_URL}?state=user&type=0&application=lsf"
+    responses.add(responses.GET, check_url, body='OK', status=200)
+    resp = client.get('/v1.0/check_session', headers={'session-cookie': 'ABC'})
+    assert resp.status_code == 200
+    assert resp.json()['is_valid'] is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,89 @@
+import json
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def create_config(tmp_path, monkeypatch):
+    config_data = {
+        "QIS": {
+            "BASE_URL": "http://testserver",
+            "SERVICE_PATH": "/service"
+        }
+    }
+    config_file = Path('config.json')
+    config_file.write_text(json.dumps(config_data))
+    yield
+    config_file.unlink()
+
+
+def test_parse_asi_parameter():
+    from versions.v1 import utils
+    importlib.reload(utils)
+    html = '<a href="page?asi=ABC123">Notenspiegel / Studienverlauf</a>'
+    assert utils.parse_asi_parameter(html) == 'ABC123'
+
+
+def test_parse_user_display_name():
+    from versions.v1 import utils
+    importlib.reload(utils)
+    spans = ''.join('<span></span>' for _ in range(8))
+    html = f'<div class="divloginstatus">{spans}Test User</div>'
+    assert utils.parse_user_display_name(html) == 'Test User'
+
+
+def test_parse_scorecard_ids():
+    from versions.v1 import utils
+    importlib.reload(utils)
+    html = '<a title="Leistungen" href="page?nodeID=NODE1">Name</a>'
+    assert utils.parse_scorecard_ids(html) == {'Name': 'NODE1'}
+
+
+def test_parse_float_int_status():
+    from versions.v1 import utils
+    importlib.reload(utils)
+    assert utils._parse_float('1,3') == 1.3
+    assert utils._parse_float('') is None
+    assert utils._parse_int('10') == 10
+    assert utils._parse_int('') is None
+    from versions.v1.models import ScoreStatus
+    assert utils._parse_status('bestanden') == ScoreStatus.PASSED
+    assert utils._parse_status('') is None
+
+
+def test_get_grade_point_average():
+    from versions.v1 import utils
+    from versions.v1.models import Module, Score, ScoreStatus, ScoreType
+    importlib.reload(utils)
+    module = Module(
+        id=1,
+        title='Mod',
+        semester='WS',
+        grade=None,
+        status=ScoreStatus.PASSED,
+        credits=5,
+        issued_on='date',
+        scores=[
+            Score(id=1, title='Score', type=ScoreType.PL, semester='WS', grade=1.0, status=ScoreStatus.PASSED, issued_on='date', attempt=1, specific_scorecard_id=None)
+        ]
+    )
+    gpa = utils.get_grade_point_average({'Cat': [module]})
+    assert gpa == 1.0
+
+def test_parse_scores(monkeypatch):
+    from versions.v1 import utils
+    from versions.v1.models import TableRow, RowType
+    importlib.reload(utils)
+
+    rows = [
+        TableRow(id='0', title='Header', type='', semester='', grade='', status='', credits='', issued_on='', attempt='', note='', free_attempt='', row_type=RowType.CATEGORY),
+        TableRow(id='1', title='Cat', type='', semester='', grade='', status='', credits='', issued_on='', attempt='', note='', free_attempt='', row_type=RowType.CATEGORY),
+        TableRow(id='101', title='Mod', type='PL', semester='WS', grade='', status='bestanden', credits='5', issued_on='2021', attempt='1', note='', free_attempt='', row_type=RowType.MODULE),
+        TableRow(id='1011', title='Score', type='PL', semester='WS', grade='1,0', status='bestanden', credits='', issued_on='2021', attempt='1', note='', free_attempt='', row_type=RowType.SCORE)
+    ]
+    monkeypatch.setattr(utils, '_parse_table_rows', lambda html: rows)
+    scores = utils.parse_scores('<html></html>')
+    assert 'Cat' in scores
+    assert scores['Cat'][0].scores[0].grade == 1.0


### PR DESCRIPTION
## Summary
- add pytest tests for utility parsing functions
- cover configuration helper with tests
- exercise FastAPI endpoints using mocked HTTP responses
- include GPA and score parsing unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505509118883289aa03382e8be96e7