### PR TITLE
Fix Python 3.7 compatibility for category parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ scorecards and grades in an efficient and user-friendly way.
 
 ### Technical Environment
 
-- FastAPI framework for building APIs with Python 3.7+ based on Pydantic and type hints.
+ - FastAPI framework for building APIs with Python 3.9+ based on Pydantic and type hints.
 - fastapi-versioning to manage version control within FastAPI endpoints.
 - Beautiful Soup for parsing HTML responses.
 - Requests library to handle HTTP requests.
@@ -43,7 +43,7 @@ scorecards and grades in an efficient and user-friendly way.
 ### Prerequisites
 
 Before you can run QISsy, ensure you have the following installed:
-- Python 3.7 or higher
+- Python 3.9 or higher
 - pip (Python package installer)
 
 ### Setup a Virtual Environment (Recommended)


### PR DESCRIPTION
## Summary
- revert compatibility workaround for dropping `Kompetenzbereich` prefix
- require Python 3.9+ in docs

## Testing
- `python3 -m py_compile versions/v1/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685054971b9c832897bdf9b216e85f72