### PR TITLE
Fix Pydantic example deprecation

### DIFF
--- a/versions/v1/models.py
+++ b/versions/v1/models.py
@@ -26,12 +26,21 @@ class SessionStatus(BaseModel):
 
 
 class ScorecardIDs(BaseModel):
-    scorecard_ids: Dict[str, str] = Field(..., example={
-        "Informatik  (PO-Version 2017)": "auswahlBaum|abschluss:abschl=82|studiengang:stg=079,pversion=2017,kzfa=H",
-        "Informatik  (PO-Version 2004)": "auswahlBaum|abschluss:abschl=82|studiengang:stg=079,pversion=2004,kzfa=H"},
-                                          description="A dictionary containing the scorecard IDs")
-    message: str = Field(..., example="Successfully retrieved scorecard IDs",
-                         description="A message indicating if the request was successful or not")
+    scorecard_ids: Dict[str, str] = Field(
+        ...,
+        examples=[
+            {
+                "Informatik  (PO-Version 2017)":             "auswahlBaum|abschluss:abschl=82|studiengang:stg=079,pversion=2017,kzfa=H",
+                "Informatik  (PO-Version 2004)": "auswahlBaum|abschluss:abschl=82|studiengang:stg=079,pversion=2004,kzfa=H",
+            }
+        ],
+        description="A dictionary containing the scorecard IDs",
+    )
+    message: str = Field(
+        ...,
+        examples=["Successfully retrieved scorecard IDs"],
+        description="A message indicating if the request was successful or not",
+    )
 
 
 class ScoreType(str, Enum):
@@ -55,19 +64,24 @@ class Score(BaseModel):
     """
     Model to represent a score.
     """
-    id: int = Field(..., example=110, description="The number of the score")
-    title: str = Field(..., example="Grundlagen der Informatik", description="The name of the score")
-    type: ScoreType = Field(..., example="Prüfungsleitung", description="The type of the score")
-    semester: str = Field(..., example="WS 2017/18", description="The semester of the score")
-    grade: Optional[float] = Field(None, example=1.3, description="The grade of the score")
-    status: ScoreStatus = Field(..., example="bestanden", description="The state of the score")
-    issued_on: str = Field(..., example="01.02.2018", description="The date of the score")
-    attempt: Optional[int] = Field(None, example=1, description="The number of tries")
-    specific_scorecard_id: Optional[str] = Field(None, example="auswahlBaum|abschluss:abschl=82|studiengang:"
-                                                               "stg=001,pversion=2017,kzfa=H|kontoOnTop:labnrzu=0000001"
-                                                               "|konto:labnrzu=0000001|konto:labnrzu=0000001|pruefung"
-                                                               ":labnr=0000001",
-                                                 description="The ID of the specific scorecard")
+    id: int = Field(..., examples=[110], description="The number of the score")
+    title: str = Field(..., examples=["Grundlagen der Informatik"], description="The name of the score")
+    type: ScoreType = Field(..., examples=["Prüfungsleitung"], description="The type of the score")
+    semester: str = Field(..., examples=["WS 2017/18"], description="The semester of the score")
+    grade: Optional[float] = Field(None, examples=[1.3], description="The grade of the score")
+    status: ScoreStatus = Field(..., examples=["bestanden"], description="The state of the score")
+    issued_on: str = Field(..., examples=["01.02.2018"], description="The date of the score")
+    attempt: Optional[int] = Field(None, examples=[1], description="The number of tries")
+    specific_scorecard_id: Optional[str] = Field(
+        None,
+        examples=[
+            "auswahlBaum|abschluss:abschl=82|studiengang:"
+            "stg=001,pversion=2017,kzfa=H|kontoOnTop:labnrzu=0000001"
+            "|konto:labnrzu=0000001|konto:labnrzu=0000001|pruefung"
+            ":labnr=0000001",
+        ],
+                                                         description="The ID of the specific scorecard"
+    )
 
 
 class Module(BaseModel):

--- a/versions/v1/user_routes.py
+++ b/versions/v1/user_routes.py
@@ -152,10 +152,18 @@ async def check_session_validity(session_cookie: str = Header(...)):  # The sess
                        500: {"description": "Internal server error", "model": ErrorResponse},
                        503: {"description": "Service temporarily unavailable", "model": ErrorResponse}})
 @version(1, 0)
-async def get_scorecard_ids(session_cookie: str = Header(..., description="The data containing the JSESSIONID cookie.",
-                                                         example="ETHEWEBNTZRH45iEGFORTNB839FHCB93.uhvqis1"),
-                            asi: str = Header(..., description="The ASI parameter.",
-                                              example="tnEJEgEd8dAPRC.kaurx")) -> ScorecardIDs:
+async def get_scorecard_ids(
+        session_cookie: str = Header(
+            ...,
+            description="The data containing the JSESSIONID cookie.",
+            examples=["ETHEWEBNTZRH45iEGFORTNB839FHCB93.uhvqis1"],
+        ),
+        asi: str = Header(
+            ...,
+            description="The ASI parameter.",
+            examples=["tnEJEgEd8dAPRC.kaurx"],
+        ),
+) -> ScorecardIDs:
     """
     :param session_cookie: The data containing the JSESSIONID cookie. (required)
     :param asi: The ASI parameter. (required)
@@ -208,11 +216,19 @@ async def get_scorecard_ids(session_cookie: str = Header(..., description="The d
                        500: {"description": "Internal server error", "model": ErrorResponse},
                        503: {"description": "Service temporarily unavailable", "model": ErrorResponse}})
 @version(1, 0)
-async def get_scorecard(scorecard_id: str,
-                        session_cookie: str = Header(..., description="The data containing the JSESSIONID cookie.",
-                                                     example="ETHEWEBNTZRH45iEGFORTNB839FHCB93.uhvqis1"),
-                        asi: str = Header(..., description="The ASI parameter.",
-                                          example="tnEJEgEd8dAPRC.kaurx")) -> Scorecard:
+async def get_scorecard(
+        scorecard_id: str,
+        session_cookie: str = Header(
+            ...,
+            description="The data containing the JSESSIONID cookie.",
+            examples=["ETHEWEBNTZRH45iEGFORTNB839FHCB93.uhvqis1"],
+        ),
+        asi: str = Header(
+            ...,
+            description="The ASI parameter.",
+            examples=["tnEJEgEd8dAPRC.kaurx"],
+        ),
+) -> Scorecard:
     """
     :param scorecard_id: The ID of the scorecard to retrieve.
     :param session_cookie: The session cookie containing the JSESSIONID.


### PR DESCRIPTION
## Summary
- replace deprecated `example` argument with `examples` lists in v1 models and routes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850768548308328b2e4b9149fb738b9