### PR TITLE
Add /info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ This API comes with a set of versioned endpoints that serve different functional
 
 ### Endpoints summary:
 
+- GET `/info` - Provides information about the running QISsy instance.
+
 - POST `/v1.0/signin` - Authenticates the user using provided credentials.
 - GET `/v1.0/check_session` - Checks whether an existing session is valid.
 - GET `/v1.0/scorecard_ids` - Retrieves the identifiers of available scorecards for the user.

--- a/main.py
+++ b/main.py
@@ -4,11 +4,19 @@ Main file for QISsy FastAPI Application
 from fastapi import FastAPI
 from fastapi_versioning import VersionedFastAPI
 
+__version__ = "0.1.0-devpreview.1"
+
 from versions.v1.user_routes import router as v1_router
 
-app = FastAPI(title="QISsy", description="A simple API to access the QIS server of a University")
+base_app = FastAPI(title="QISsy", description="A simple API to access the QIS server of a University")
 
-app.include_router(v1_router)
+base_app.include_router(v1_router)
 
-app = VersionedFastAPI(app=app, enable_latest=True, prefix_format="/v{major}.{minor}",
+app = VersionedFastAPI(app=base_app, enable_latest=True, prefix_format="/v{major}.{minor}",
                        version_format="{major}.{minor}")
+
+
+@app.get("/info")
+async def info():
+    """Return information about this QISsy instance."""
+    return {"name": "QISsy", "version": __version__}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -85,3 +85,13 @@ def test_get_scorecard_returns_credit_sum(config_and_client, monkeypatch):
     data = resp.json()
     assert data['grade_point_average'] == 1.0
     assert data['credit_point_sum'] == 30
+
+
+def test_info_endpoint(config_and_client):
+    client = config_and_client
+    import main
+    resp = client.get('/info')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['name'] == 'QISsy'
+    assert data['version'] == main.__version__


### PR DESCRIPTION
## Summary
- expose version info at `/info`
- test the new endpoint
- document the new route in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507c8a070c832883690d12c22ba14e