### PR TITLE
Add test for missing ASI link

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,14 @@ def test_parse_asi_parameter():
     assert utils.parse_asi_parameter(html) == 'ABC123'
 
 
+def test_parse_asi_parameter_missing_link():
+    """Return None if the link is missing."""
+    from versions.v1 import utils
+    importlib.reload(utils)
+    html = '<a href="page?asi=ABC123">Wrong link</a>'
+    assert utils.parse_asi_parameter(html) is None
+
+
 def test_parse_user_display_name():
     from versions.v1 import utils
     importlib.reload(utils)


### PR DESCRIPTION
## Summary
- extend test coverage for `parse_asi_parameter`
- ensure `parse_asi_parameter` returns `None` when the link is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507ed8ef7483289316450b82977bea