### PR TITLE
Fix example typo in Score model

### DIFF
--- a/versions/v1/models.py
+++ b/versions/v1/models.py
@@ -66,7 +66,7 @@ class Score(BaseModel):
     """
     id: int = Field(..., examples=[110], description="The number of the score")
     title: str = Field(..., examples=["Grundlagen der Informatik"], description="The name of the score")
-    type: ScoreType = Field(..., examples=["Prüfungsleitung"], description="The type of the score")
+    type: ScoreType = Field(..., examples=["Prüfungsleistung"], description="The type of the score")
     semester: str = Field(..., examples=["WS 2017/18"], description="The semester of the score")
     grade: Optional[float] = Field(None, examples=[1.3], description="The grade of the score")
     status: ScoreStatus = Field(..., examples=["bestanden"], description="The state of the score")


### PR DESCRIPTION
## Summary
- correct German typo in `Score` model example for `type` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850885645fc8328847c7800bcc07a71