### PR TITLE
Fix unversioned info endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,14 +8,30 @@ __version__ = "0.1.0-devpreview.1"
 
 from versions.v1.user_routes import router as v1_router
 
-base_app = FastAPI(title="QISsy", description="A simple API to access the QIS server of a University")
 
-base_app.include_router(v1_router)
+def create_app() -> FastAPI:
+    """Create and return the FastAPI application."""
+    base_app = FastAPI(
+        title="QISsy",
+        description="A simple API to access the QIS server of a University",
+    )
 
-@base_app.get("/info")
-async def info():
+    base_app.include_router(v1_router)
+
+    versioned_app = VersionedFastAPI(
+        app=base_app,
+        enable_latest=True,
+        prefix_format="/v{major}.{minor}",
+        version_format="{major}.{minor}",
+    )
+
+    return versioned_app
+
+
+app = create_app()
+
+
+@app.get("/info")
+async def info() -> dict[str, str]:
     """Return information about this QISsy instance."""
     return {"name": "QISsy", "version": __version__}
-
-app = VersionedFastAPI(app=base_app, enable_latest=True, prefix_format="/v{major}.{minor}",
-                       version_format="{major}.{minor}")


### PR DESCRIPTION
## Summary
- expose `/info` from versioned app so other versioned routes work
- create app factory for easier initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f0fd8fb483288c430f854c793308