### PR TITLE
Update deployment workflow for self-hosted runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,35 +7,19 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - testserver-1
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
       - name: Build Docker Image
-        run: docker build --build-arg CONFIG_CONTENT='${{ secrets.CONFIG }}' -t my_fastapi_app .
+        run: docker build --build-arg CONFIG_CONTENT='${{ secrets.CONFIG }}' -t qissy .
 
-      - name: Save Docker Image
-        run: docker save -o my_fastapi_app.tar my_fastapi_app
-
-      - name: Copy Docker Image to Remote Server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          source: "./my_fastapi_app.tar"
-          target: "/root/QISsy"
-
-      - name: Deploy to Remote Server
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
-            docker stop my_fastapi_app || true
-            docker rm my_fastapi_app || true
-            docker load < /root/QISsy/my_fastapi_app.tar
-            docker run -d --name my_fastapi_app -p 8000:8000 my_fastapi_app
+      - name: Deploy Container
+        run: |
+          docker stop qissy || true
+          docker rm qissy || true
+          docker run -d --name qissy -p 127.0.0.1:8000:8000 qissy


### PR DESCRIPTION
## Summary
- simplify deploy workflow
- run deployment directly on self-hosted runner with label `testserver-1`
- deploy container bound to localhost for use behind reverse proxy
- rename container to `qissy`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68585ba92b9483288b70cfad400fcc6f