### PR TITLE
Add environment variable fallback for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,15 @@ cd QISsy
 pip install -r requirements.txt
 ```
 
-3. Copy the example config to a new file and fill in your qis server url.
+3. Copy the example config to a new file and fill in your QIS server URL.
 
 ```sh
 cp config_example.json config.json
 ```
+
+If `config.json` is missing at runtime, QISsy will try to read the values from
+environment variables. Set `QIS_BASE_URL` and `QIS_SERVICE_PATH` to the
+appropriate values when running without a configuration file.
 
 ### Running the APP
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 
 def get_config_value(config_key: str) -> str:
@@ -15,12 +16,18 @@ def get_config_value(config_key: str) -> str:
     References: config_example.json
 
     """
+    env_var = "_".join(config_key.split("/")).upper()
     try:
         with open('config.json', 'r') as f:
             settings = json.load(f)
     except FileNotFoundError:
-        raise FileNotFoundError("The config.json file was not found. Please create a config.json file in the "
-                                "root directory of the project.")
+        env_value = os.getenv(env_var)
+        if env_value is not None:
+            return env_value
+        raise FileNotFoundError(
+            "The config.json file was not found and environment variable "
+            f"{env_var} is not set."
+        )
 
     keys = config_key.split('/')
     value = settings
@@ -29,7 +36,12 @@ def get_config_value(config_key: str) -> str:
         for key in keys:
             value = value[key]
     except KeyError:
-        raise KeyError(f"The setting {config_key} was not found in the config.json file. "
-                       "Please add the setting to the config.json file.")
+        env_value = os.getenv(env_var)
+        if env_value is not None:
+            return env_value
+        raise KeyError(
+            f"The setting {config_key} was not found in the config.json file and "
+            f"environment variable {env_var} is not set."
+        )
 
     return value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,33 +1,53 @@
 import json
-from pathlib import Path
 import importlib
+
 import pytest
 
 
+def reload_config():
+    cfg = importlib.import_module('config')
+    importlib.reload(cfg)
+    return cfg
+
+
 def test_get_config_value_success(tmp_path, monkeypatch):
-    cfg = {"QIS": {"BASE_URL": "http://x", "SERVICE_PATH": "/s"}}
+    cfg_data = {"QIS": {"BASE_URL": "http://x", "SERVICE_PATH": "/s"}}
     config_file = tmp_path / 'config.json'
-    config_file.write_text(json.dumps(cfg))
+    config_file.write_text(json.dumps(cfg_data))
     monkeypatch.chdir(tmp_path)
-    config = importlib.import_module('config')
-    importlib.reload(config)
-    assert config.get_config_value('QIS/BASE_URL') == 'http://x'
+    cfg = reload_config()
+    assert cfg.get_config_value('QIS/BASE_URL') == 'http://x'
 
 
-def test_get_config_value_missing_file(tmp_path, monkeypatch):
+def test_get_config_value_missing_file_env(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    config = importlib.import_module('config')
-    importlib.reload(config)
+    monkeypatch.setenv('QIS_BASE_URL', 'http://env')
+    cfg = reload_config()
+    assert cfg.get_config_value('QIS/BASE_URL') == 'http://env'
+
+
+def test_get_config_value_missing_file_no_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = reload_config()
     with pytest.raises(FileNotFoundError):
-        config.get_config_value('QIS/BASE_URL')
+        cfg.get_config_value('QIS/BASE_URL')
 
 
-def test_get_config_value_key_error(tmp_path, monkeypatch):
-    cfg = {"QIS": {}}
+def test_get_config_value_key_error_env(tmp_path, monkeypatch):
+    cfg_data = {"QIS": {}}
     config_file = tmp_path / 'config.json'
-    config_file.write_text(json.dumps(cfg))
+    config_file.write_text(json.dumps(cfg_data))
     monkeypatch.chdir(tmp_path)
-    config = importlib.import_module('config')
-    importlib.reload(config)
+    monkeypatch.setenv('QIS_BASE_URL', 'http://env')
+    cfg = reload_config()
+    assert cfg.get_config_value('QIS/BASE_URL') == 'http://env'
+
+
+def test_get_config_value_key_error_no_env(tmp_path, monkeypatch):
+    cfg_data = {"QIS": {}}
+    config_file = tmp_path / 'config.json'
+    config_file.write_text(json.dumps(cfg_data))
+    monkeypatch.chdir(tmp_path)
+    cfg = reload_config()
     with pytest.raises(KeyError):
-        config.get_config_value('QIS/BASE_URL')
+        cfg.get_config_value('QIS/BASE_URL')


### PR DESCRIPTION
## Summary
- allow reading configuration from environment variables when `config.json` is missing
- update README instructions on configuration
- expand tests for new fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812ba2d4108328b393140fbd0d191a