### PR TITLE
Add robots.txt endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ This API comes with a set of versioned endpoints that serve different functional
 ### Endpoints summary:
 
 - GET `/info` - Provides information about the running QISsy instance.
+- GET `/robots.txt` - Disallows all web crawlers.
 
 - POST `/v1.0/signin` - Authenticates the user using provided credentials.
 - GET `/v1.0/check_session` - Checks whether an existing session is valid.

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 Main file for QISsy FastAPI Application
 """
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 from fastapi_versioning import VersionedFastAPI
 
 __version__ = "v1.0"
@@ -35,3 +36,9 @@ app = create_app()
 async def info() -> dict[str, str]:
     """Return information about this QISsy instance."""
     return {"name": "QISsy", "version": __version__}
+
+
+@app.get("/robots.txt", include_in_schema=False)
+async def robots_txt() -> PlainTextResponse:
+    """Disallow all web crawlers."""
+    return PlainTextResponse("User-agent: *\nDisallow: /")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -106,3 +106,10 @@ def test_info_endpoint(config_and_client):
     data = resp.json()
     assert data['name'] == 'QISsy'
     assert data['version'] == main.__version__
+
+
+def test_robots_txt(config_and_client):
+    client = config_and_client
+    resp = client.get('/robots.txt')
+    assert resp.status_code == 200
+    assert resp.text == "User-agent: *\nDisallow: /"


### PR DESCRIPTION
## Summary
- implement `/robots.txt` endpoint that returns a disallow all policy
- document new endpoint
- test the robots.txt endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688519ad6b788328a3692913c3f9c5eb