### PR TITLE
Add GPA progress data to scorecard

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ This API comes with a set of versioned endpoints that serve different functional
 - GET `/v1.0/scorecard_ids` - Retrieves the identifiers of available scorecards for the user.
 - GET `/v1.0/scorecard` - Fetches a particular scorecard using its identifier.
 
+  The response contains the current grade point average, the total credit
+  sum and a timeline of how the grade point average evolved over time.
+
 Each endpoint requires specific input parameters and returns respective responses which are documented in detail using 
 Pydantic models and can be viewed on the Swagger/OpenAPI documentation available at `http://127.0.0.1:8000/v1.0/redoc`
 once the server is running.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -88,7 +88,7 @@ def test_get_scorecard_returns_credit_sum(config_and_client, monkeypatch):
         grade=None,
         status=ScoreStatus.PASSED,
         credits=5,
-        issued_on='date',
+        issued_on='01.01.2020',
         scores=[
             Score(
                 id=11,
@@ -97,7 +97,7 @@ def test_get_scorecard_returns_credit_sum(config_and_client, monkeypatch):
                 semester='WS',
                 grade=1.0,
                 status=ScoreStatus.PASSED,
-                issued_on='date',
+                issued_on='01.01.2020',
                 attempt=1,
                 specific_scorecard_id=None,
             )
@@ -110,7 +110,7 @@ def test_get_scorecard_returns_credit_sum(config_and_client, monkeypatch):
         grade=None,
         status=ScoreStatus.PASSED,
         credits=10,
-        issued_on='date',
+        issued_on='10.02.2020',
         scores=[
             Score(
                 id=22,
@@ -119,7 +119,7 @@ def test_get_scorecard_returns_credit_sum(config_and_client, monkeypatch):
                 semester='SS',
                 grade=None,
                 status=ScoreStatus.PASSED,
-                issued_on='date',
+                issued_on='10.02.2020',
                 attempt=1,
                 specific_scorecard_id=None,
             )
@@ -144,6 +144,8 @@ def test_get_scorecard_returns_credit_sum(config_and_client, monkeypatch):
     data = resp.json()
     assert data['grade_point_average'] == 1.0
     assert data['credit_point_sum'] == 15
+    assert len(data['grade_point_average_progress']) == 1
+    assert data['grade_point_average_progress'][0]['grade_point_average'] == 1.0
 
 
 def test_info_endpoint(config_and_client):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,44 @@ def test_get_grade_point_average():
     assert gpa == 1.0
 
 
+def test_get_grade_point_average_progress():
+    from versions.v1 import utils
+    from versions.v1.models import Module, Score, ScoreStatus, ScoreType
+    importlib.reload(utils)
+
+    module1 = Module(
+        id=1,
+        title='Mod1',
+        semester='WS',
+        grade=None,
+        status=ScoreStatus.PASSED,
+        credits=5,
+        issued_on='01.01.2020',
+        scores=[
+            Score(id=11, title='Score1', type=ScoreType.PL, semester='WS', grade=1.0,
+                  status=ScoreStatus.PASSED, issued_on='01.01.2020', attempt=1, specific_scorecard_id=None)
+        ]
+    )
+    module2 = Module(
+        id=2,
+        title='Mod2',
+        semester='WS',
+        grade=None,
+        status=ScoreStatus.PASSED,
+        credits=5,
+        issued_on='10.02.2020',
+        scores=[
+            Score(id=22, title='Score2', type=ScoreType.PL, semester='WS', grade=2.0,
+                  status=ScoreStatus.PASSED, issued_on='10.02.2020', attempt=1, specific_scorecard_id=None)
+        ]
+    )
+
+    progress = utils.get_grade_point_average_progress({'Cat': [module1, module2]})
+    assert len(progress) == 2
+    assert progress[0].grade_point_average == 1.0
+    assert progress[1].grade_point_average == 1.5
+
+
 def test_get_credit_point_sum():
     from versions.v1 import utils
     from versions.v1.models import Module, Score, ScoreStatus, ScoreType

--- a/versions/v1/models.py
+++ b/versions/v1/models.py
@@ -121,6 +121,15 @@ class Module(BaseModel):
     }]])
 
 
+class GradePointAverageProgressItem(BaseModel):
+    """Model to represent a grade point average data point."""
+
+    module_id: int = Field(..., examples=[1], description="ID of the module that updated the GPA")
+    grade_point_average: float = Field(
+        ..., examples=[1.0], description="The grade point average after this module")
+    date: str = Field(..., examples=["01.01.2020"], description="The date of the module grade")
+
+
 class Scorecard(BaseModel):
     """
     Model to represent a scorecard.
@@ -128,6 +137,11 @@ class Scorecard(BaseModel):
     scores: dict[str, List[Module]] # Category name as key and list of Module as value
     grade_point_average: Optional[float] = Field(None, examples=[1.3], description="The grade point average")
     credit_point_sum: Optional[int] = Field(None, examples=[180], description="The sum of credit points")
+    grade_point_average_progress: Optional[List[GradePointAverageProgressItem]] = Field(
+        None,
+        description="List of GPA data points over time",
+        examples=[[{"module_id": 1, "grade_point_average": 1.0, "date": "01.01.2020"}]],
+    )
     message: str = Field(..., examples=["Successfully retrieved scorecard"],
                          description="A message indicating if the request was successful or not")
 

--- a/versions/v1/user_routes.py
+++ b/versions/v1/user_routes.py
@@ -6,8 +6,18 @@ from fastapi import HTTPException, Header
 from fastapi_versioning import version
 
 from .models import ErrorResponse, UserCredentials, UserSignInDetails, SessionStatus, ScorecardIDs, Scorecard, Module
-from .utils import SERVICE_BASE_URL, parse_asi_parameter, parse_user_display_name, _session_is_valid, \
-    parse_scorecard_ids, parse_scores, validate_session_or_raise, get_grade_point_average, get_credit_point_sum
+from .utils import (
+    SERVICE_BASE_URL,
+    parse_asi_parameter,
+    parse_user_display_name,
+    _session_is_valid,
+    parse_scorecard_ids,
+    parse_scores,
+    validate_session_or_raise,
+    get_grade_point_average,
+    get_grade_point_average_progress,
+    get_credit_point_sum,
+)
 
 router = APIRouter()
 
@@ -281,9 +291,11 @@ async def get_scorecard(
 
     grade_point_average = get_grade_point_average(scores)
     credit_point_sum = get_credit_point_sum(scores)
+    grade_point_average_progress = get_grade_point_average_progress(scores)
 
     # Return the scorecard.
     return Scorecard(scores=scores,
                      grade_point_average=grade_point_average,
                      credit_point_sum=credit_point_sum,
+                     grade_point_average_progress=grade_point_average_progress,
                      message="Successfully retrieved scorecard")


### PR DESCRIPTION
## Summary
- return GPA progress timeline along with scorecard data
- compute GPA progression based on module grades
- test scorecard GPA timeline and add utility tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf6cda8ad883288cd11505469cca00